### PR TITLE
Add monitor auto-switch startup hook for Hyprland

### DIFF
--- a/hyprland.conf
+++ b/hyprland.conf
@@ -6,3 +6,6 @@ general {
     col.active_border = rgba(e48b7aee) rgba(f0a19aee) 45deg
     col.inactive_border = rgba(0a122088)
 }
+# Monitor auto-switch startup hook (managed by install-monitor-auto-switch.sh)
+exec-once = /etc/acpi/check-lid-on-startup.sh
+exec = /etc/acpi/check-lid-on-startup.sh


### PR DESCRIPTION
This commit adds monitor auto-switching functionality to the Hyprland configuration, which will help users with laptops automatically switch between displays when opening or closing the lid.